### PR TITLE
Web monetization cookies

### DIFF
--- a/HapiWebMonetization.js
+++ b/HapiWebMonetization.js
@@ -1,0 +1,111 @@
+const { randomBytes } = require('crypto')
+const { createReceiver } = require('ilp-protocol-psk2')
+const EventEmitter = require('events')
+const getIlpPlugin = require('ilp-plugin')
+const debug = require('debug')('hapi-web-monetization')
+const Boom = require('boom')
+
+class HapiWebMonetization {
+  constructor (opts) {
+    this.settings = opts
+
+    this.connected = false
+    this.plugin = (opts && opts.plugin) || getIlpPlugin()
+    this.buckets = new Map()
+    this.balanceEvents = new EventEmitter()
+    // Max balance is set so that user does not have an infinite amount of credit on site.
+    this.maxBalance = (opts && opts.maxBalance) || Infinity
+  }
+
+  connect () {
+    if (!this.connected) {
+      this.connected = this._connect()
+    }
+
+    return this.connected
+  }
+
+  async _connect () {
+    await this.plugin.connect()
+
+    // Start crediting the balance of a user on the site every second.
+    this.receiver = await createReceiver({
+      plugin: this.plugin,
+      paymentHandler: async params => {
+        const amount = params.prepare.amount
+        const id = params.prepare.destination.split('.').slice(-3)[0]
+
+        let balance = this.buckets.get(id) || 0
+        balance = Math.min(balance + Number(amount), this.maxBalance)
+        this.buckets.set(id, balance)
+        setImmediate(() => this.balanceEvents.emit(id, balance))
+        debug('got money for bucket. amount=' + amount,
+          'id=' + id,
+          'balance=' + balance)
+        // Wait for chunk of payment to be accepted before calling again.
+        await params.acceptSingleChunk()
+      }
+    })
+  }
+
+  async awaitBalance (id, balance) {
+    debug('awaiting balance. id=' + id, 'balance=' + balance)
+    return new Promise(resolve => {
+      const handleBalanceUpdate = _balance => {
+        if (_balance < balance) return
+
+        setImmediate(() =>
+          this.balanceEvents.removeListener(id, handleBalanceUpdate))
+        resolve()
+      }
+
+      this.balanceEvents.on(id, handleBalanceUpdate)
+    })
+  }
+
+  spend (id, price) {
+    // Spend credit accumulated from browser monetising user on site. E.g. Viewing paid content.
+    const balance = this.buckets.get(id)
+    if (!balance) {
+      throw new Error('Balance does not exist - you must add a wallet.')
+    }
+    if (balance < price) {
+      throw new Error('insufficient balance on id.' +
+      ' id=' + id,
+      ' price=' + price,
+      ' balance=' + balance)
+    }
+    debug('spent credit, id=' + id, 'price=' + price)
+    this.buckets.set(id, balance - price)
+  }
+
+  async receive (request, reply) {
+    await this.connect()
+
+    if (request.headers.accept !== 'application/spsp+json') {
+      throw Boom.notFound('Wrong headers')
+    }
+    const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+    const segments = destinationAccount.split('.')
+
+    const resultAccount = segments.slice(0, -2).join('.') +
+    '.' + request.params.id +
+    '.' + segments.slice(-2).join('.')
+
+    const response = reply.response({
+      destination_account: resultAccount,
+      shared_secret: sharedSecret.toString('base64')
+    })
+    response.type('application/spsp+json')
+    return response
+  }
+
+  generatePayerId (request) {
+    if (request.state[this.settings.cookieName]) {
+      return request.state[this.settings.cookieName]
+    }
+    return randomBytes(16).toString('hex')
+  }
+}
+
+module.exports = HapiWebMonetization

--- a/HapiWebMonetization.js
+++ b/HapiWebMonetization.js
@@ -48,7 +48,7 @@ class HapiWebMonetization {
     })
   }
 
-  async awaitBalance (id, balance) {
+  awaitBalance (id, balance) {
     debug('awaiting balance. id=' + id, 'balance=' + balance)
     return new Promise(resolve => {
       const handleBalanceUpdate = _balance => {

--- a/README.md
+++ b/README.md
@@ -33,23 +33,23 @@ section.
 ```js
 const Hapi = require('hapi')
 
-const WebMonetization = require('hapi-web-monetization')
-const monetization = new WebMonetization()
-
 const server = Hapi.server({
   port: 8080,
   host: 'localhost'
 })
 
-function payMiddleware (request, reply) {
-  // This is the 'middleware' that allows the endpoint to charge 100 units to the user with request.params.id
-  // If awaitBalance is set to true, the call will stay open until the balance is sufficient. This is convenience
-  // for making sure that the call doesn't immediately fail when called on startup.
-  return monetization.paid({ price: 100, awaitBalance: true })
+const options = {
+  cookieOptions: {
+    isSecure: true
+  }
 }
 
 const start = async () => {
   await server.register(require('inert'))
+  await server.register({
+    plugin: require('hapi-web-monetization'),
+    options
+  })
 
   server.route([
     {
@@ -57,15 +57,6 @@ const start = async () => {
       path: '/',
       handler: function (request, reply) {
         // Load index page
-      }
-    },
-    {
-      method: 'GET',
-      path: '/pay/{id}',
-      handler: async function (request, reply) {
-        // This is the SPSP endpoint that lets you receive ILP payments.  Money that
-        // comes in is associated with the :id
-        return monetization.receive(request, reply)
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ const server = Hapi.server({
 
 function payMiddleware (request, reply) {
   // This is the 'middleware' that allows the endpoint to charge 100 units to the user with request.params.id
-  // If awaitBalance is set to true, the call will stay open until the balance is sufficient. This is convenienct
+  // If awaitBalance is set to true, the call will stay open until the balance is sufficient. This is convenience
   // for making sure that the call doesn't immediately fail when called on startup.
-  return monetization.paid(request, reply, { price: 100, awaitBalance: true })
+  return monetization.paid({ price: 100, awaitBalance: true })
 }
 
 const start = async () => {

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@
   - [Prerequisites](#prerequisites)
   - [Install and Run](#install-and-run)
 - [API Docs](#api-docs)
-  - [Constructor](#constructor)
-  - [Receiver](#receiver)
-  - [Paid](#paid)
+  - [Server Register Options](#server-register-options)
+  - [Charging users](#charging-users)
 
 ## Overview
 
@@ -61,17 +60,11 @@ const start = async () => {
     },
     {
       method: 'GET',
-      path: '/content/{id}',
-      config: {
-        pre: [
-          {
-            method: payMiddleware,
-            assign: 'paid'
-          }
-        ],
-        handler: async function (request, reply) {
-          // Load content by :content_id
-        }
+      path: '/content/',
+      handler: async function (request, reply) {
+        await request.awaitBalance(100)
+        request.spend(100)
+        // Send paid content
       }
     },
   ])
@@ -90,14 +83,17 @@ The client side code to support this is very simple too:
 ```html
 <script src="node_modules/hapi-web-monetization/client.js"></script>
 <script>
-  getMonetizationId('http://localhost:8080/pay/:id')
-    .then(id => {
+  var monetizerClient = new MonetizerClient();
+  monetizerClient.start()
+    .then(function() {
       var img = document.createElement('img')
       var container = document.getElementById('container')
-
-      img.src = '/content/' + id
+      img.src = '/content/'
       img.width = '600'
       container.appendChild(img)
+    })
+    .catch(function(error){
+      console.log("Error", error);
     })
 </script>
 ```
@@ -134,45 +130,36 @@ is coming in. Once the user has paid 100 units, the example image will load on
 the page.
 
 ## API Docs
-
-### Constructor
-
-```ts
-new HapiWebMonetization(opts: Object | void): HapiWebMonetization
-```
-
-Create a new `HapiWebMonetization` instance.
-
-- `opts.plugin` - Supply an ILP plugin. Defaults to using Moneyd.
-- `opts.maxBalance` - The maximum balance that can be associated with any user. Defaults to `Infinity`.
-
-### Receiver
+### Server register options
 
 ```ts
-instance.receiver(): Function
+  server.register({
+    plugin: require('hapi-web-monetization'),
+    options : Object | void
+  })
 ```
 
-Returns an object for setting up Interledger payments with
-[SPSP](https://github.com/sharafian/ilp-protocol-spsp) (used in Web
-Monetization).
+Registers a new `HapiWebMonetization` plugin which creates and sets cookie for the payer ID in the browser.
+- `options.plugin` - Supply an ILP plugin. Defaults to using Moneyd.
+- `options.maxBalance` - The maximum balance that can be associated with any user. Defaults to `Infinity`.
+- `options.receiveEndpointUrl` - The endpoint in your Hapi route configuration that specifies where a user pays streams PSK packets to your site. Defaults to `/__monetizer/{id}` where `{id}` is the server generated ID (stored in the browser as a cookie).
+- `options.cookieName` - The cookie key name for your server generated payer ID. Defaults to `__monetizer`
+- `options.cookie` - Cookie configurations for Hapi. See [Hapi server state options](https://hapijs.com/api#-serverstatename-options) for more details!
 
-The endpoint on which this is attached must contain `:id` in the path. This represents the id of the paying user.
 
-### Paid
+### Charging users
+
+The methods `request.spend()` and `request.awaitBalance()` are available to use inside handlers.
 
 ```ts
-instance.paid(opts: Object): Function
+request.spend(amount): Function
 ```
+Specifies how many units to charge the user.
 
-- `opts.price` - Function that takes Hapi `request` and returns price, or a number.
-  Specifies how many units to charge the user. Required.
-- `opts.awaitBalance` - Whether to make the HTTP call wait until the user has
-  sufficient balance. Defaults to `false`.
-
-Charges the user whose `:id` is in the path.  It
-is meant to be chained with other middlewares through Hapi's pre configuration, as shown in the [example
-code](#example-code)
-
+```ts
+request.awaitBalance(amount): Function
+```
+Waits until the user has sufficient balance to pay for specific content.
 `awaitBalance` can be useful for when a call is being done at page start.
 Rather than immediately failing because the user hasn't paid, the server will
 wait until the user has paid the specified price.

--- a/client.js
+++ b/client.js
@@ -17,7 +17,6 @@ function MonetizerClient(opts) {
           // set cookie and/or receiverUrl.
           // document.cookie = response.id
           self.receiverUrl = self.receiverUrl.replace(/:id/, response.id)
-          console.log("document cookies", document.cookie)
           let responseId = response.id
           setCookie('payerId', response.id, 2)
           resolve(responseId)
@@ -47,10 +46,10 @@ function MonetizerClient(opts) {
 }
 
 function setCookie(cname, cvalue, exdays) {
-    var d = new Date();
-    d.setTime(d.getTime() + (exdays*24*60*60*1000));
-    var expires = "expires="+ d.toUTCString();
-    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+    var d = new Date()
+    d.setTime(d.getTime() + (exdays*24*60*60*1000))
+    var expires = "expires="+ d.toUTCString()
+    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/"
 }
 
 function u8tohex (arr) {

--- a/client.js
+++ b/client.js
@@ -14,8 +14,7 @@ function MonetizerClient(opts) {
           return response.json()
         })
         .then(function(response) {
-          // set cookie and/or receiverUrl.
-          // document.cookie = response.id
+          // Set cookie and receiverUrl.
           self.receiverUrl = self.receiverUrl.replace(/:id/, response.id)
           let responseId = response.id
           setCookie('payerId', response.id, 2)

--- a/client.js
+++ b/client.js
@@ -1,3 +1,68 @@
+function MonetizerClient(opts) {
+  var domain = new URL(window.location).origin
+  this.url = domain
+  if(opts && opts.url) {
+    this.url = opts.url;
+  }
+  this.receiverUrl = this.url + '/pay/:id'
+  this.getMonetizationId = function(getMonetizationIdUrl) {
+    return new Promise ((resolve, reject) => {
+      const fetchUrl = (getMonetizationIdUrl )|| this.url + '/getMonetizationId'
+      console.log("fetchURL", fetchUrl);
+      var self = this;
+      fetch(fetchUrl)
+        .then(function(response) {
+          return response.json();
+        })
+        .then(function(response) {
+          // set cookie and/or receiverUrl.
+          // document.cookie = response.id;
+          self.receiverUrl = self.receiverUrl.replace(/:id/, response.id);
+          console.log("document cookies", document.cookie);
+          let responseId = response.id
+          // if(document.cookie) {
+          //   responseId = document.cookie.split('=')[1]
+          //   console.log("cookei id", responseId)
+          // } else {
+          //   document.cookie = setCookie('payerId', response.id, 3);
+          //   responseId = response.id
+          // }
+          console.log("responseId", responseId)
+          resolve(responseId)
+        })
+        .catch(function(error) {
+          reject(new Error(error))
+        })
+    })
+
+  }
+  this.start = function(id) {
+    var self = this;
+    return new Promise((resolve, reject) => {
+      if(window.monetize) {
+        window.monetize({
+          receiver: self.receiverUrl
+        })
+        resolve(id)
+      } else {
+        console.log('Your extension is disabled or not installed.' +
+          ' Manually pay to ' + self.receiverUrl)
+        reject(new Error('web monetization is not enabled'))
+      }
+    })
+  }
+}
+
+function setCookie(name,value,days) {
+    var expires = "";
+    if (days) {
+        var date = new Date();
+        date.setTime(date.getTime() + (days*24*60*60*1000));
+        expires = "; expires=" + date.toUTCString();
+    }
+    document.cookie = name + "=" + (value || "")  + expires + "; path=/";
+}
+
 function u8tohex (arr) {
   var vals = [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' ]
   var ret = ''
@@ -6,26 +71,4 @@ function u8tohex (arr) {
     ret += vals[(arr[i] & 0x0f)]
   }
   return ret
-}
-
-function getMonetizationId (receiverUrl) {
-  return new Promise((resolve, reject) => {
-    window.addEventListener('load', function () {
-      var idBytes = new Uint8Array(16)
-      crypto.getRandomValues(idBytes)
-      var id = u8tohex(idBytes)
-      var receiver = receiverUrl.replace(/:id/, id)
-      // Checks for extension or browser injection of window.monetize
-      if (window.monetize) {
-        window.monetize({
-          receiver
-        })
-        resolve(id)
-      } else {
-        console.log('Your extension is disabled or not installed.' +
-          ' Manually pay to ' + receiver)
-        reject(new Error('web monetization is not enabled'))
-      }
-    })
-  })
 }

--- a/client.js
+++ b/client.js
@@ -2,32 +2,24 @@ function MonetizerClient(opts) {
   var domain = new URL(window.location).origin
   this.url = domain
   if(opts && opts.url) {
-    this.url = opts.url;
+    this.url = opts.url
   }
   this.receiverUrl = this.url + '/pay/:id'
   this.getMonetizationId = function(getMonetizationIdUrl) {
     return new Promise ((resolve, reject) => {
       const fetchUrl = (getMonetizationIdUrl )|| this.url + '/getMonetizationId'
-      console.log("fetchURL", fetchUrl);
-      var self = this;
+      var self = this
       fetch(fetchUrl)
         .then(function(response) {
-          return response.json();
+          return response.json()
         })
         .then(function(response) {
           // set cookie and/or receiverUrl.
-          // document.cookie = response.id;
-          self.receiverUrl = self.receiverUrl.replace(/:id/, response.id);
-          console.log("document cookies", document.cookie);
+          // document.cookie = response.id
+          self.receiverUrl = self.receiverUrl.replace(/:id/, response.id)
+          console.log("document cookies", document.cookie)
           let responseId = response.id
-          // if(document.cookie) {
-          //   responseId = document.cookie.split('=')[1]
-          //   console.log("cookei id", responseId)
-          // } else {
-          //   document.cookie = setCookie('payerId', response.id, 3);
-          //   responseId = response.id
-          // }
-          console.log("responseId", responseId)
+          setCookie('payerId', response.id, 2)
           resolve(responseId)
         })
         .catch(function(error) {
@@ -37,8 +29,9 @@ function MonetizerClient(opts) {
 
   }
   this.start = function(id) {
-    var self = this;
+    var self = this
     return new Promise((resolve, reject) => {
+
       if(window.monetize) {
         window.monetize({
           receiver: self.receiverUrl
@@ -53,14 +46,11 @@ function MonetizerClient(opts) {
   }
 }
 
-function setCookie(name,value,days) {
-    var expires = "";
-    if (days) {
-        var date = new Date();
-        date.setTime(date.getTime() + (days*24*60*60*1000));
-        expires = "; expires=" + date.toUTCString();
-    }
-    document.cookie = name + "=" + (value || "")  + expires + "; path=/";
+function setCookie(cname, cvalue, exdays) {
+    var d = new Date();
+    d.setTime(d.getTime() + (exdays*24*60*60*1000));
+    var expires = "expires="+ d.toUTCString();
+    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
 }
 
 function u8tohex (arr) {

--- a/example/index.html
+++ b/example/index.html
@@ -9,15 +9,34 @@
   </div>
   <script src="/client.js"></script>
   <script>
-    getMonetizationId('http://localhost:8080/pay/:id')
-      .then(id => {
-        console.log("ID", id);
-        var img = document.createElement('img')
-        var container = document.getElementById('container')
-        img.src = '/content/' + id
-        img.width = '600'
-        container.appendChild(img)
-      })
+    console.log("monetizer", MonetizerClient);
+    var monetizerClient = new MonetizerClient();
+    monetizerClient.getMonetizationId()
+    .then(function(id) {
+      console.log("start here");
+      return monetizerClient.start()
+    })
+    .then(function() {
+          console.log("wat")
+          var img = document.createElement('img')
+          var container = document.getElementById('container')
+          img.src = '/content/'
+          img.width = '600'
+          container.appendChild(img)
+    })
+    .catch(function(error){
+        console.log("Error", error);
+    })
+
+    // getMonetizationId('http://localhost:8080/pay/:id')
+    //   .then(id => {
+    //     console.log("ID", id);
+    //     var img = document.createElement('img')
+    //     var container = document.getElementById('container')
+    //     img.src = '/content/' + id
+    //     img.width = '600'
+    //     container.appendChild(img)
+    //   })
   </script>
 </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -9,15 +9,12 @@
   </div>
   <script src="/client.js"></script>
   <script>
-    console.log("monetizer", MonetizerClient);
     var monetizerClient = new MonetizerClient();
     monetizerClient.getMonetizationId()
     .then(function(id) {
-      console.log("start here");
       return monetizerClient.start()
     })
     .then(function() {
-          console.log("wat")
           var img = document.createElement('img')
           var container = document.getElementById('container')
           img.src = '/content/'
@@ -27,16 +24,6 @@
     .catch(function(error){
         console.log("Error", error);
     })
-
-    // getMonetizationId('http://localhost:8080/pay/:id')
-    //   .then(id => {
-    //     console.log("ID", id);
-    //     var img = document.createElement('img')
-    //     var container = document.getElementById('container')
-    //     img.src = '/content/' + id
-    //     img.width = '600'
-    //     container.appendChild(img)
-    //   })
   </script>
 </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -1,5 +1,11 @@
 <html>
 <head>
+  <script>
+    document.addEventListener('readystatechange', () => {
+      console.log('readyState', document.readyState)
+      console.log('monetize', window.monetize)
+    })
+  </script>
 </head>
 <body>
   <h1>Hello World</h1>
@@ -10,20 +16,17 @@
   <script src="/client.js"></script>
   <script>
     var monetizerClient = new MonetizerClient();
-    monetizerClient.getMonetizationId()
-    .then(function(id) {
-      return monetizerClient.start()
-    })
-    .then(function() {
-          var img = document.createElement('img')
-          var container = document.getElementById('container')
-          img.src = '/content/'
-          img.width = '600'
-          container.appendChild(img)
-    })
-    .catch(function(error){
+    monetizerClient.start()
+      .then(function() {
+        var img = document.createElement('img')
+        var container = document.getElementById('container')
+        img.src = '/content/'
+        img.width = '600'
+        container.appendChild(img)
+      })
+      .catch(function(error){
         console.log("Error", error);
-    })
+      })
   </script>
 </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -1,11 +1,5 @@
 <html>
 <head>
-  <script>
-    document.addEventListener('readystatechange', () => {
-      console.log('readyState', document.readyState)
-      console.log('monetize', window.monetize)
-    })
-  </script>
 </head>
 <body>
   <h1>Hello World</h1>

--- a/example/index.js
+++ b/example/index.js
@@ -9,8 +9,15 @@ const server = Hapi.server({
 
 const start = async () => {
   await server.register(require('inert'))
-  await server.register(require('..'))
-  
+  await server.register({
+    plugin: require('..'),
+    options: {
+      cookieOptions: {
+        isSecure: false
+      }
+    }
+  })
+
   server.route([
     {
       method: 'GET',
@@ -21,26 +28,12 @@ const start = async () => {
     },
     {
       method: 'GET',
-      path: '/getMonetizationId',
-      handler: function (request, reply) {
-        return request.monetizer.generateAndStoreId(request, reply);
-      }
-    },
-    {
-      method: 'GET',
-      path: '/pay/{id}',
-      handler: function(request, reply) {
-        return request.monetizer.receive(request, reply);
-      }
-    },
-    {
-      method: 'GET',
       path: '/content/',
       config: {
-
         handler: async function (request, reply) {
-          request.monetizer.spend(100)
-          await request.monetizer.awaitBalance(100)
+          await request.awaitBalance(100)
+          // request.monetizer.spend(100)
+          // await request.monetizer.awaitBalance(100)
           const file = await fs.readFile(path.resolve(__dirname, 'content.jpg'))
           return file
         }

--- a/example/index.js
+++ b/example/index.js
@@ -1,21 +1,29 @@
 const Hapi = require('hapi')
 const path = require('path')
 const fs = require('fs-extra')
-const HapiWebMonetization = require('..')
-const monetization = new HapiWebMonetization()
+// const HapiWebMonetization = require('..')
+// const monetization = new HapiWebMonetization()
 
+// Register on top of Yar, and  check if monetized based on balance === 0; Build on top yar. Set ID of paying user. Server generates cookie. registered whole thing. generate ID on server side. .startPaying. monetizer.start
 const server = Hapi.server({
   port: 8080,
   host: 'localhost'
 })
 
-function payMiddleware (request, reply) {
-  return monetization.paid(request, reply, { price: 100, awaitBalance: true })
-}
+// function payMiddleware (request, reply) {
+//   return monetization.paid(request, reply, { price: 100, awaitBalance: true })
+// }
 
 const start = async () => {
   await server.register(require('inert'))
-
+  await server.register(require('..'))
+  server.state('data', {
+    ttl: null,     // One day
+    isSecure: false,
+    isHttpOnly: true,
+    encoding: 'base64json',
+    clearInvalid: false,
+  });
   server.route([
     {
       method: 'GET',
@@ -26,22 +34,26 @@ const start = async () => {
     },
     {
       method: 'GET',
-      path: '/pay/{id}',
-      handler: async function (request, reply) {
-        return monetization.receive(request, reply)
+      path: '/getMonetizationId',
+      handler: function (request, reply) {
+        return request.monetizer.generateAndStoreId(request, reply);
       }
     },
     {
       method: 'GET',
-      path: '/content/{id}',
+      path: '/pay/{id}',
+      handler: function(request, reply) {
+        return request.monetizer.receive(request, reply);
+      }
+    },
+    {
+      method: 'GET',
+      path: '/content/',
       config: {
-        pre: [
-          {
-            method: payMiddleware,
-            assign: 'paid'
-          }
-        ],
+
         handler: async function (request, reply) {
+          request.monetizer.spend(100)
+          await request.monetizer.awaitBalance(100)
           const file = await fs.readFile(path.resolve(__dirname, 'content.jpg'))
           return file
         }

--- a/example/index.js
+++ b/example/index.js
@@ -29,15 +29,13 @@ const start = async () => {
     {
       method: 'GET',
       path: '/content/',
-      config: {
-        handler: async function (request, reply) {
-          await request.awaitBalance(100)
-          // request.monetizer.spend(100)
-          // await request.monetizer.awaitBalance(100)
-          const file = await fs.readFile(path.resolve(__dirname, 'content.jpg'))
-          return file
-        }
+      handler: async function (request, reply) {
+        await request.awaitBalance(100)
+        request.spend(100)
+        const file = await fs.readFile(path.resolve(__dirname, 'content.jpg'))
+        return file
       }
+
     },
     {
       method: 'GET',

--- a/example/index.js
+++ b/example/index.js
@@ -1,29 +1,16 @@
 const Hapi = require('hapi')
 const path = require('path')
 const fs = require('fs-extra')
-// const HapiWebMonetization = require('..')
-// const monetization = new HapiWebMonetization()
 
-// Register on top of Yar, and  check if monetized based on balance === 0; Build on top yar. Set ID of paying user. Server generates cookie. registered whole thing. generate ID on server side. .startPaying. monetizer.start
 const server = Hapi.server({
   port: 8080,
   host: 'localhost'
 })
 
-// function payMiddleware (request, reply) {
-//   return monetization.paid(request, reply, { price: 100, awaitBalance: true })
-// }
-
 const start = async () => {
   await server.register(require('inert'))
   await server.register(require('..'))
-  server.state('data', {
-    ttl: null,     // One day
-    isSecure: false,
-    isHttpOnly: true,
-    encoding: 'base64json',
-    clearInvalid: false,
-  });
+  
   server.route([
     {
       method: 'GET',

--- a/index.js
+++ b/index.js
@@ -3,115 +3,167 @@ const EventEmitter = require('events')
 const getIlpPlugin = require('ilp-plugin')
 const debug = require('debug')('hapi-web-monetization')
 const Boom = require('boom')
-
-class HapiWebMonetization {
-  constructor (opts) {
-    this.connected = false
-    this.plugin = (opts && opts.plugin) || getIlpPlugin()
-    this.buckets = new Map()
-    this.balanceEvents = new EventEmitter()
-    // Max balance is set so that user does not have an infinite amount of credit on site.
-    this.maxBalance = (opts && opts.maxBalance) || Infinity
+const Hoek = require('hoek');
+var getRandomValues = require('get-random-values');
+// const internals = {
+//   connected: false,
+//   buckets: new Map(),
+//   balanceEvents: new EventEmitter(),
+//   defaults: {
+//     plugin: getIlpPlugin(),
+//     maxBalance: Infinity
+//   }
+// }
+function u8tohex (arr) {
+  var vals = [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' ]
+  var ret = ''
+  for (var i = 0; i < arr.length; ++i) {
+    ret += vals[(arr[i] & 0xf0) / 0x10]
+    ret += vals[(arr[i] & 0x0f)]
   }
-
-  async connect () {
-    if (this.connected) return
-    this.connected = true
-    await this.plugin.connect()
-    // Start crediting the balance of a user on the site every second.
-    this.receiver = await createReceiver({
-      plugin: this.plugin,
-      paymentHandler: async params => {
-        const amount = params.prepare.amount
-        const id = params.prepare.destination.split('.').slice(-3)[0]
-
-        let balance = this.buckets.get(id) || 0
-        balance = Math.min(balance + Number(amount), this.maxBalance)
-        this.buckets.set(id, balance)
-        setImmediate(() => this.balanceEvents.emit(id, balance))
-        debug('got money for bucket. amount=' + amount,
-          'id=' + id,
-          'balance=' + balance)
-        // Wait for chunk of payment to be accepted before calling again.
-        await params.acceptSingleChunk()
-      }
-    })
-  }
-
-  awaitBalance (id, balance) {
-    debug('awaiting balance. id=' + id, 'balance=' + balance)
-    return new Promise(resolve => {
-      const handleBalanceUpdate = _balance => {
-        if (_balance < balance) return
-
-        setImmediate(() =>
-          this.balanceEvents.removeListener(id, handleBalanceUpdate))
-        resolve()
-      }
-
-      this.balanceEvents.on(id, handleBalanceUpdate)
-    })
-  }
-
-  spend (id, price) {
-    // Spend credit accumulated from browser monetising user on site. E.g. Viewing paid content.
-    const balance = this.buckets.get(id)
-    if (!balance) {
-      throw new Error('Balance does not exist - you must add a wallet.')
-    }
-    if (balance < price) {
-      throw new Error('insufficient balance on id.' +
-      ' id=' + id,
-      ' price=' + price,
-      ' balance=' + balance)
-    }
-    debug('spent credit, id=' + id, 'price=' + price)
-    this.buckets.set(id, balance - price)
-  }
-
-  async paid (request, reply, { price, awaitBalance = false }) {
-    // Returns async function which is passed as middleware
-    const id = request.params.id
-
-    if (!id) {
-      var error = new Error('Undefined ID')
-      Boom.boomify(error, { statusCode: 400 })
-    }
-    const _price = (typeof price === 'function')
-      ? Number(price(request))
-      : Number(price)
-
-    if (awaitBalance) {
-      await this.awaitBalance(id, _price)
-    }
-
-    try {
-      this.spend(id, _price)
-      return 'Spent'
-    } catch (e) {
-      throw Boom.paymentRequired(e.message)
-    }
-  }
-
-  async receive (request, reply) {
-    await this.connect()
-    if (request.headers.accept !== 'application/spsp+json') {
-      throw Boom.notFound('Wrong headers')
-    }
-    const {destinationAccount, sharedSecret} = this.receiver.generateAddressAndSecret()
-    const segments = destinationAccount.split('.')
-
-    const resultAccount = segments.slice(0, -2).join('.') +
-    '.' + request.params.id +
-    '.' + segments.slice(-2).join('.')
-
-    const response = reply.response({
-      destination_account: resultAccount,
-      shared_secret: sharedSecret.toString('base64')
-    })
-    response.type('application/spsp+json')
-    return response
-  }
+  return ret
 }
 
-module.exports = HapiWebMonetization
+exports.register = (server, options, next) => {
+
+  class HapiWebMonetization {
+    constructor (opts) {
+      this.connected = false
+      this.plugin = (opts && opts.plugin) || getIlpPlugin()
+      this.buckets = new Map()
+      this.balanceEvents = new EventEmitter()
+      // Max balance is set so that user does not have an infinite amount of credit on site.
+      this.maxBalance = (opts && opts.maxBalance) || Infinity
+      this.cache = server.cache({
+        segment: 'payerId', expiresIn: 60 * 60 * 1000
+      })
+    }
+    async generateAndStoreId(request, reply) {
+      let cachedId = await this.cache.get('payerId')
+      console.log("CACHED", cachedId);
+      let id;
+      if(!cachedId) {
+        var idBytes = new Uint8Array(16)
+        getRandomValues(idBytes)
+        //This will be the cookie value.
+        id = u8tohex(idBytes)
+        this.cache.set('payerId', id);
+      }
+      if(cachedId) {
+        id = cachedId
+      }
+
+      return reply.response({ id })
+
+    }
+    async connect () {
+      if (this.connected) return
+      this.connected = true
+      await this.plugin.connect()
+      // Start crediting the balance of a user on the site every second.
+      this.receiver = await createReceiver({
+        plugin: this.plugin,
+        paymentHandler: async params => {
+          const amount = params.prepare.amount
+          const id = await this.cache.get('payerId')
+          let balance = this.buckets.get(id) || 0
+          balance = Math.min(balance + Number(amount), this.maxBalance)
+          this.buckets.set(id, balance)
+          setImmediate(() => this.balanceEvents.emit(id, balance))
+          debug('got money for bucket. amount=' + amount,
+            'id=' + id,
+            'balance=' + balance)
+          // Wait for chunk of payment to be accepted before calling again.
+          await params.acceptSingleChunk()
+        }
+      })
+    }
+
+    async awaitBalance (balance) {
+      const id = await this.cache.get('payerId')
+      debug('awaiting balance. id=' + id, 'balance=' + balance)
+      return new Promise(resolve => {
+        const handleBalanceUpdate = _balance => {
+          if (_balance < balance) return
+
+          setImmediate(() =>
+            this.balanceEvents.removeListener(id, handleBalanceUpdate))
+          resolve()
+        }
+
+        this.balanceEvents.on(id, handleBalanceUpdate)
+      })
+    }
+
+    async spend (price) {
+      // Spend credit accumulated from browser monetising user on site. E.g. Viewing paid content.
+      const id = await this.cache.get('payerId')
+      console.log("ID", id, this.buckets);
+      const balance = this.buckets.get(id)
+      if (!balance) {
+        throw new Error('Balance does not exist - you must add a wallet.')
+      }
+      if (balance < price) {
+        throw new Error('insufficient balance on id.' +
+        ' id=' + id,
+        ' price=' + price,
+        ' balance=' + balance)
+      }
+      debug('spent credit, id=' + id, 'price=' + price)
+      this.buckets.set(id, balance - price)
+    }
+
+    paid ({ price, awaitBalance = false }) {
+      // Returns async function which is passed as middleware
+      return async (request, reply) => {
+        const id = await this.cache.get('payerId')
+
+        if (!id) {
+          var error = new Error('Undefined ID')
+          Boom.boomify(error, { statusCode: 400 })
+        }
+        const _price = (typeof price === 'function')
+          ? Number(price(request))
+          : Number(price)
+
+        if (awaitBalance) {
+          await this.awaitBalance(id, _price)
+        }
+
+        try {
+          this.spend(id, _price)
+          return 'Spent'
+        } catch (e) {
+          throw Boom.paymentRequired(e.message)
+        }
+      }
+
+    }
+
+    async receive (request, reply){
+      await this.connect()
+
+      if (request.headers.accept !== 'application/spsp+json') {
+        throw Boom.notFound('Wrong headers')
+      }
+      const {destinationAccount, sharedSecret} = this.receiver.generateAddressAndSecret()
+      const segments = destinationAccount.split('.')
+
+      const resultAccount = segments.slice(0, -2).join('.') +
+      '.' + request.params.id +
+      '.' + segments.slice(-2).join('.')
+
+      const response = reply.response({
+        destination_account: resultAccount,
+        shared_secret: sharedSecret.toString('base64')
+      })
+      console.log("response", response)
+      response.type('application/spsp+json')
+      return response
+    }
+  }
+
+  server.decorate('request', 'monetizer', new HapiWebMonetization());
+}
+
+exports.pkg = require('./package.json');

--- a/index.js
+++ b/index.js
@@ -1,166 +1,42 @@
-const {createReceiver} = require('ilp-protocol-psk2')
-const EventEmitter = require('events')
-const getIlpPlugin = require('ilp-plugin')
-const debug = require('debug')('hapi-web-monetization')
-const Boom = require('boom')
-var getRandomValues = require('get-random-values')
+const Hoek = require('hoek')
+const HapiWebMonetization = require('./HapiWebMonetization')
 
-function u8tohex (arr) {
-  var vals = [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' ]
-  var ret = ''
-  for (var i = 0; i < arr.length; ++i) {
-    ret += vals[(arr[i] & 0xf0) / 0x10]
-    ret += vals[(arr[i] & 0x0f)]
+const DEFAULT_OPTIONS = {
+  plugin: null,
+  maxBalance: Infinity,
+  receiveEndpointUrl: '/__monetizer/{id}',
+  cookieName: '__monetizer',
+  cookieOptions: {
+    clearInvalid: true,
+    ignoreErrors: true,
+    isSameSite: 'Lax',
+    isHttpOnly: false,
+    isSecure: true,
+    path: '/'
   }
-  return ret
 }
 
-exports.register = (server, options, next) => {
+exports.register = async (server, options, next) => {
+  const settings = Hoek.applyToDefaults(DEFAULT_OPTIONS, options)
 
-  class HapiWebMonetization {
-    constructor (opts) {
-      this.connected = false
-      this.plugin = (opts && opts.plugin) || getIlpPlugin()
-      this.buckets = new Map()
-      this.balanceEvents = new EventEmitter()
-      // Max balance is set so that user does not have an infinite amount of credit on site.
-      this.maxBalance = (opts && opts.maxBalance) || Infinity
-      this.cache = server.cache({
-        segment: 'payerId', expiresIn: 60 * 60 * 1000
-      })
-    }
-    async generateAndStoreId(request, reply) {
-      let cachedId = await this.cache.get('payerId')
-      let id
-      if(!cachedId) {
-        var idBytes = new Uint8Array(16)
-        getRandomValues(idBytes)
-        //This will be the cookie value.
-        id = u8tohex(idBytes)
-        this.cache.set('payerId', id)
-      }
-      if(cachedId) {
-        id = cachedId
-      }
-      const maxAge = 60 * 60 * 100
-      var cookie_options = {
-        ttl: null, // expires a year from today
-        encoding: 'none', // we already used JWT to encode
-        isSecure: false, // warm & fuzzy feelings
-        isHttpOnly: false, // prevent client alteration
-        path: '/',
-        domain: 'localhost',
-      }
-      //header('Set-Cookie', 'payerId=' + id + '; ' + 'Max-Age=' + maxAge + '; ' + 'path=/; ' + 'SameSite=Lax;')
-      return reply.response({ id }).header('Set-Cookie', 'payerId=' + id + '; ' + 'Domain=localhost:8080; ' + 'path=/; ' + 'SameSite=Lax;')
+  const monetizer = new HapiWebMonetization(settings)
+  await monetizer.connect()
 
-    }
-    async connect () {
-      if (this.connected) return
-      this.connected = true
-      await this.plugin.connect()
-      // Start crediting the balance of a user on the site every second.
-      this.receiver = await createReceiver({
-        plugin: this.plugin,
-        paymentHandler: async params => {
-          const amount = params.prepare.amount
-          const id = await this.cache.get('payerId')
-          let balance = this.buckets.get(id) || 0
-          balance = Math.min(balance + Number(amount), this.maxBalance)
-          this.buckets.set(id, balance)
-          setImmediate(() => this.balanceEvents.emit(id, balance))
-          debug('got money for bucket. amount=' + amount,
-            'id=' + id,
-            'balance=' + balance)
-          // Wait for chunk of payment to be accepted before calling again.
-          await params.acceptSingleChunk()
-        }
-      })
-    }
+  ;['awaitBalance', 'spend'].forEach(key => {
+    server.decorate('request', key, function (amount) {
+      return monetizer[key](this.state[settings.cookieName], amount)
+    })
+  })
+  const cookieOptions = Object.assign({
+    autoValue: monetizer.generatePayerId.bind(monetizer)
+  }, settings.cookieOptions)
+  server.state(settings.cookieName, cookieOptions)
 
-    async awaitBalance (balance) {
-      const id = await this.cache.get('payerId')
-      debug('awaiting balance. id=' + id, 'balance=' + balance)
-      return new Promise(resolve => {
-        const handleBalanceUpdate = _balance => {
-          if (_balance < balance) return
-
-          setImmediate(() =>
-            this.balanceEvents.removeListener(id, handleBalanceUpdate))
-          resolve()
-        }
-
-        this.balanceEvents.on(id, handleBalanceUpdate)
-      })
-    }
-
-    async spend (price) {
-      // Spend credit accumulated from browser monetising user on site. E.g. Viewing paid content.
-      const id = await this.cache.get('payerId')
-      const balance = this.buckets.get(id)
-      if (!balance) {
-        throw new Error('Balance does not exist - you must add a wallet.')
-      }
-      if (balance < price) {
-        throw new Error('insufficient balance on id.' +
-        ' id=' + id,
-        ' price=' + price,
-        ' balance=' + balance)
-      }
-      debug('spent credit, id=' + id, 'price=' + price)
-      this.buckets.set(id, balance - price)
-    }
-
-    paid ({ price, awaitBalance = false }) {
-      // Returns async function which is passed as middleware
-      return async (request, reply) => {
-        const id = await this.cache.get('payerId')
-
-        if (!id) {
-          var error = new Error('Undefined ID')
-          Boom.boomify(error, { statusCode: 400 })
-        }
-        const _price = (typeof price === 'function')
-          ? Number(price(request))
-          : Number(price)
-
-        if (awaitBalance) {
-          await this.awaitBalance(id, _price)
-        }
-
-        try {
-          this.spend(id, _price)
-          return 'Spent'
-        } catch (e) {
-          throw Boom.paymentRequired(e.message)
-        }
-      }
-
-    }
-
-    async receive (request, reply){
-      await this.connect()
-
-      if (request.headers.accept !== 'application/spsp+json') {
-        throw Boom.notFound('Wrong headers')
-      }
-      const {destinationAccount, sharedSecret} = this.receiver.generateAddressAndSecret()
-      const segments = destinationAccount.split('.')
-
-      const resultAccount = segments.slice(0, -2).join('.') +
-      '.' + request.params.id +
-      '.' + segments.slice(-2).join('.')
-
-      const response = reply.response({
-        destination_account: resultAccount,
-        shared_secret: sharedSecret.toString('base64')
-      })
-      response.type('application/spsp+json')
-      return response
-    }
-  }
-
-  server.decorate('request', 'monetizer', new HapiWebMonetization())
+  server.route([{
+    method: 'GET',
+    path: settings.receiveEndpointUrl,
+    handler: monetizer.receive.bind(monetizer)
+  }])
 }
 
 exports.pkg = require('./package.json')

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ exports.register = (server, options, next) => {
         isHttpOnly: false, // prevent client alteration
         path: '/',
         domain: 'localhost',
-      };
+      }
       //header('Set-Cookie', 'payerId=' + id + '; ' + 'Max-Age=' + maxAge + '; ' + 'path=/; ' + 'SameSite=Lax;')
       return reply.response({ id }).header('Set-Cookie', 'payerId=' + id + '; ' + 'Domain=localhost:8080; ' + 'path=/; ' + 'SameSite=Lax;')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,6 +470,11 @@
         "esutils": "2.0.2"
       }
     },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -813,6 +818,14 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-random-values": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-random-values/-/get-random-values-1.2.0.tgz",
+      "integrity": "sha1-MpIO3oG+2YJl/0A3HPSSmb1YHvE=",
+      "requires": {
+        "global": "4.3.2"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -825,6 +838,15 @@
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
+      }
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       }
     },
     "globals": {
@@ -1289,6 +1311,14 @@
         "mime-db": "1.33.0"
       }
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1534,6 +1564,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "debug": "^3.1.0",
     "get-random-values": "^1.2.0",
-    "hoek": "^5.0.3",
     "ilp-plugin": "^3.1.0",
     "ilp-protocol-psk2": "^0.2.1",
     "inert": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "debug": "^3.1.0",
+    "get-random-values": "^1.2.0",
+    "hoek": "^5.0.3",
     "ilp-plugin": "^3.1.0",
     "ilp-protocol-psk2": "^0.2.1",
     "inert": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "get-random-values": "^1.2.0",
+    "hoek": "^5.0.3",
     "ilp-plugin": "^3.1.0",
     "ilp-protocol-psk2": "^0.2.1",
     "inert": "^5.1.0"


### PR DESCRIPTION
Simplify API to generate a payer ID on the server side and persist this through cookies. Web monetization sites now only need to decide how much to charge their users and whether they should wait for sufficient balance until content is loaded.